### PR TITLE
Enable universal bdist_wheel flag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [flake8]
 ignore = E127, E128, E241, E402, E501, E731
 exclude =


### PR DESCRIPTION
Use a universal wheel distribution because this library is both python 2 and 3 compatible.