### PR TITLE
Test against python 3.6 dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+cache: pip
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
           env: TOXENV=py34
         - python: 3.5
           env: TOXENV=py35
+        - python: 3.6-dev
+          env: TOXENV=py36
         - python: 2.7
           env: TOXENV=qa
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ addons:
   apt:
     packages:
     - libsdl1.2-dev
+    - libfreetype6-dev
+    - libjpeg8-dev
 
 install: pip install -U pip tox coveralls
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ matrix:
         - python: 2.7
           env: TOXENV=qa
 
+addons:
+  apt:
+    packages:
+    - libsdl1.2-dev
+
 install: pip install -U pip tox coveralls
 script: tox
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ matrix:
           env: TOXENV=py36
         - python: 2.7
           env: TOXENV=qa
-
+    allow_failures:
+        - python: 3.6-dev
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ addons:
   apt:
     packages:
     - libsdl1.2-dev
+    - libsdl-image1.2-dev
+    - libsdl-mixer1.2-dev
+    - libsdl-ttf2.0-dev
+    - libportmidi-dev
     - libfreetype6-dev
     - libjpeg8-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ addons:
     - libjpeg8-dev
 
 install: pip install -U pip tox coveralls
-script: tox
+script: tox -vv
 after_success:
   - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35},qa
+envlist = py{27,34,35,36},qa
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Python 3.6 is going to be released this month so and testing on travis is already possible using `3.6-dev`. Unfortunately there's no pygame wheel available yet so it tries to compile pygame from source which fails due to a packaging issue with pygame. The build is allowed to fail for py3.6 for now, and we should disable that as soon as there's a py3.6 wheel for pygame. This PR also installs the actual pygame dependencies (which takes about 45 secs) and enables pip caching (which scrapes of build time).