### PR TITLE
Enable universal wheel distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ addons:
     - libjpeg8-dev
 
 install: pip install -U pip tox coveralls
-script: tox
+script: tox -vv
 after_success:
   - coveralls


### PR DESCRIPTION
Use a universal wheel distribution because this library is both python 2 and 3 compatible.