### PR TITLE
Add savepoint/restore functionality - fixes #73

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ ChangeLog
 +------------+---------------------------------------------------------------------+------------+
 | Version    | Description                                                         | Date       |
 +============+=====================================================================+============+
-| *Upcoming* | * Add terminal functionality                                        |            |
+| *Upcoming* | * Add savepoint/restore functionality                               |            |
+|            | * Add terminal functionality                                        |            |
 |            | * Canvas image dithering                                            |            |
 |            | * Additional & improved examples                                    |            |
 |            | * Load config settings from file (for examples)                     |            |

--- a/doc/python-usage.rst
+++ b/doc/python-usage.rst
@@ -68,6 +68,7 @@ invaders.py     Space Invaders demo
 maze.py         Maze generator
 perfloop.py     Simple benchmarking utility to measure performance
 pi_logo.py      Display the Raspberry Pi logo (loads image as .png)
+savepoint.py    Example of savepoint/restore functionality
 starfield.py    3D starfield simulation
 sys_info.py     Display basic system information
 terminal.py     Simple println capabilities

--- a/examples/savepoint.py
+++ b/examples/savepoint.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# PYTHON_ARGCOMPLETE_OK
+
+import time
+from demo_opts import device
+from oled.virtual import history
+from oled.render import canvas
+
+
+def render_box(draw, idx, color):
+    message = "Nesting level: {0}".format(idx)
+    width, height = draw.textsize(message)
+    left = idx * 4
+    right = left + width + 2
+    top = idx * 4
+    bottom = top + height + 2
+
+    draw.rectangle((left, top, right, bottom), outline="white", fill="black")
+    draw.text((left + 2, top + 1), text=message, fill=color)
+
+
+def main():
+    colors = ["red", "green", "blue", "yellow", "magenta", "cyan"]
+    hist = history(device)
+
+    while True:
+
+        # Phase 1: Redraw on a fresh canvas each loop
+        for idx, color in enumerate(colors):
+            with canvas(hist) as draw:
+                render_box(draw, idx, color)
+
+            hist.savepoint()
+            time.sleep(1)
+
+        while len(hist) > 0:
+            # Drop every other save point
+            hist.restore(drop=1)
+            time.sleep(1)
+
+        # Phase 2: Notice the difference with the above?
+        # ... redraw on the *same* canvas
+        c = canvas(hist)
+        for idx, color in enumerate(colors):
+            with c as draw:
+                render_box(draw, idx, color)
+
+            hist.savepoint()
+            time.sleep(1)
+
+        while len(hist) > 0:
+            hist.restore()
+            time.sleep(1)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass

--- a/oled/emulator.py
+++ b/oled/emulator.py
@@ -178,6 +178,29 @@ class pygame(emulator):
         self._pygame.display.flip()
 
 
+class dummy(emulator):
+    """
+    Pseudo-device that acts like an OLED display, except that it does nothing
+    other than retain a copy of the displayed image. It is mostly useful for
+    testing. While the capability of an OLED device is monochrome, there is no
+    limitation here, and hence supports 24-bit color depth.
+    """
+    def __init__(self, width=128, height=64, mode="RGB", transform="scale2x",
+                 scale=2, **kwargs):
+        super(dummy, self).__init__(width, height, mode, transform, scale)
+        self.image = None
+
+    def display(self, image):
+        """
+        Takes a :py:mod:`PIL.Image` and makes a copy of it for later
+        use/inspection.
+        """
+        assert(image.size[0] == self.width)
+        assert(image.size[1] == self.height)
+
+        self.image = image.copy()
+
+
 class transformer(object):
     """
     Helper class used to dispatch transformation operations.

--- a/tests/test_emulator.py
+++ b/tests/test_emulator.py
@@ -7,7 +7,7 @@ import hashlib
 import os.path
 from tempfile import NamedTemporaryFile
 
-from oled.emulator import capture, gifanim
+from oled.emulator import capture, gifanim, dummy
 from oled.render import canvas
 
 import baseline_data
@@ -19,8 +19,7 @@ def md5(fname):
 
 
 def test_capture_noops():
-    fname = NamedTemporaryFile(suffix=".png").name
-    device = capture(file_template=fname, transform="none")
+    device = dummy()
     # All these should have no effect
     device.hide()
     device.show()

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2016 Richard Hull and contributors
+# See LICENSE.rst for details.
+
+
+import pytest
+
+from oled.render import canvas
+from oled.virtual import history
+from oled.emulator import dummy
+
+import baseline_data
+
+
+def test_restore_throws_error_when_empty():
+    device = dummy()
+    hist = history(device)
+    assert len(hist) == 0
+    with pytest.raises(IndexError):
+        hist.restore()
+
+
+def test_save_and_restore_reverts_image():
+    device = dummy()
+    hist = history(device)
+
+    with canvas(hist) as draw:
+        baseline_data.primitives(hist, draw)
+
+    img1 = device.image
+    hist.savepoint()
+    assert len(hist) == 1
+
+    with canvas(hist) as draw:
+        draw.text((10, 10), text="Hello", fill="white")
+
+    img2 = device.image
+    assert img1 != img2
+    hist.restore()
+    img3 = device.image
+    assert img1 == img3
+    assert len(hist) == 0
+
+
+def test_drop_and_restore():
+    device = dummy()
+    hist = history(device)
+
+    copies = []
+    for i in range(10):
+        with canvas(hist) as draw:
+            draw.text((10, 10), text="Hello {0}".format(i), fill="white")
+        hist.savepoint()
+        copies.append(device.image)
+
+    hist.restore()
+    assert device.image == copies[9]
+    hist.restore(drop=2)
+    assert device.image == copies[6]
+    hist.restore(drop=4)
+    assert device.image == copies[1]
+    assert len(hist) == 1


### PR DESCRIPTION
history class wraps a device, and provides the same capabilities to
draw with, but adds a savepoint() method that pushes the last drawn
image onto a stack, and a restore() method that pops the most recent
image from the stack and redraws it.